### PR TITLE
feat: add activity indicator to TextInput

### DIFF
--- a/example/src/Examples/TextInputExample.tsx
+++ b/example/src/Examples/TextInputExample.tsx
@@ -114,13 +114,7 @@ const TextInputExample = () => {
     maxLengthName,
     flatTextSecureEntry,
     outlineTextSecureEntry,
-    iconsColor: {
-      flatLeftIcon,
-      flatRightIcon,
-      outlineLeftIcon,
-      outlineRightIcon,
-      customIcon,
-    },
+    iconsColor: { flatLeftIcon, flatRightIcon, outlineLeftIcon, customIcon },
   } = state;
 
   const _isUsernameValid = (name: string) => /^[a-zA-Z]*$/.test(name);
@@ -301,15 +295,8 @@ const TextInputExample = () => {
                 inputActionHandler('outlinedLargeText', outlinedLargeText)
               }
               left={<TextInput.Affix text="$" />}
-              right={
-                <TextInput.Icon
-                  icon="magnify"
-                  color={outlineRightIcon}
-                  onPress={() => {
-                    changeIconColor('outlineRightIcon');
-                  }}
-                />
-              }
+              loading={true} //! This is a test prop. Don't merge it
+              useNativeLoadingIndicator={true} //! This is a test prop. Don't merge it
             />
             <TextInput
               mode="outlined"

--- a/example/src/Examples/TextInputExample.tsx
+++ b/example/src/Examples/TextInputExample.tsx
@@ -114,7 +114,13 @@ const TextInputExample = () => {
     maxLengthName,
     flatTextSecureEntry,
     outlineTextSecureEntry,
-    iconsColor: { flatLeftIcon, flatRightIcon, outlineLeftIcon, customIcon },
+    iconsColor: {
+      flatLeftIcon,
+      flatRightIcon,
+      outlineLeftIcon,
+      outlineRightIcon,
+      customIcon,
+    },
   } = state;
 
   const _isUsernameValid = (name: string) => /^[a-zA-Z]*$/.test(name);
@@ -209,6 +215,19 @@ const TextInputExample = () => {
               }
             />
             <TextInput
+              style={styles.inputContainerStyle}
+              label="Flat input with Activity Indicator"
+              placeholder="Type something"
+              value={text}
+              onChangeText={(text) => inputActionHandler('text', text)}
+              maxLength={100}
+              right={
+                <TextInput.ActivityIndicator
+                  useNativeActivityIndicator={true}
+                />
+              }
+            />
+            <TextInput
               style={[styles.inputContainerStyle, styles.fontSize]}
               label="Flat input large font"
               placeholder="Type something"
@@ -287,6 +306,20 @@ const TextInputExample = () => {
             />
             <TextInput
               mode="outlined"
+              style={styles.inputContainerStyle}
+              label="Outlined with Activity Indicator"
+              placeholder="Press the icon to submit"
+              value={text}
+              onChangeText={(text) => inputActionHandler('text', text)}
+              maxLength={100}
+              right={
+                <TextInput.ActivityIndicator
+                  useNativeActivityIndicator={true}
+                />
+              }
+            />
+            <TextInput
+              mode="outlined"
               style={[styles.inputContainerStyle, styles.fontSize]}
               label="Outlined large font"
               placeholder="Type something"
@@ -295,8 +328,15 @@ const TextInputExample = () => {
                 inputActionHandler('outlinedLargeText', outlinedLargeText)
               }
               left={<TextInput.Affix text="$" />}
-              loading={true} //! This is a test prop. Don't merge it
-              useNativeLoadingIndicator={true} //! This is a test prop. Don't merge it
+              right={
+                <TextInput.Icon
+                  icon="magnify"
+                  color={outlineRightIcon}
+                  onPress={() => {
+                    changeIconColor('outlineRightIcon');
+                  }}
+                />
+              }
             />
             <TextInput
               mode="outlined"

--- a/src/components/TextInput/Adornment/TextInputActivityIndicator.tsx
+++ b/src/components/TextInput/Adornment/TextInputActivityIndicator.tsx
@@ -1,0 +1,126 @@
+import React from 'react';
+import {
+  StyleSheet,
+  StyleProp,
+  ViewStyle,
+  View,
+  ActivityIndicator as RNActivityIndicator,
+} from 'react-native';
+
+import { getIconColor } from './utils';
+import { useInternalTheme } from '../../../core/theming';
+import { $Omit, ThemeProp } from '../../../types';
+import ActivityIndicator from '../../ActivityIndicator';
+import { Props as ActivityIndicatorProps } from '../../ActivityIndicator';
+import { ICON_SIZE } from '../constants';
+import { getConstants } from '../helpers';
+
+export type Props = $Omit<
+  ActivityIndicatorProps,
+  'size' | 'hidesWhenStopped'
+> & {
+  /**
+   * When true, the loading indicator will be the React Native default ActivityIndicator.
+   */
+  useNativeActivityIndicator?: boolean;
+};
+
+type StyleContextType = {
+  style: StyleProp<ViewStyle>;
+  isTextInputFocused: boolean;
+  testID: string;
+  disabled?: boolean;
+};
+
+const StyleContext = React.createContext<StyleContextType>({
+  style: {},
+  isTextInputFocused: false,
+  testID: '',
+});
+
+const ActivityIndicatorAdornment: React.FunctionComponent<
+  {
+    testID: string;
+    indicator: React.ReactNode;
+    topPosition: number;
+    side: 'left' | 'right';
+    theme?: ThemeProp;
+    disabled?: boolean;
+    useNativeActivityIndicator?: boolean;
+  } & Omit<StyleContextType, 'style'>
+> = ({
+  indicator,
+  topPosition,
+  side,
+  isTextInputFocused,
+  testID,
+  theme: themeOverrides,
+  disabled,
+}) => {
+  const { isV3 } = useInternalTheme(themeOverrides);
+  const { ICON_OFFSET } = getConstants(isV3);
+
+  const style: StyleProp<ViewStyle> = {
+    top: topPosition,
+    [side]: ICON_OFFSET,
+  };
+  const contextState = {
+    style,
+    isTextInputFocused,
+    side,
+    testID,
+    disabled,
+  };
+
+  return (
+    <StyleContext.Provider value={contextState}>
+      {indicator}
+    </StyleContext.Provider>
+  );
+};
+
+const TextInputActivityIndicator = ({
+  useNativeActivityIndicator,
+  color: customColor,
+  theme: themeOverrides,
+  ...rest
+}: Props) => {
+  const { style, isTextInputFocused, testID, disabled } =
+    React.useContext(StyleContext);
+
+  const theme = useInternalTheme(themeOverrides);
+
+  const indicatorColor = getIconColor({
+    theme,
+    disabled,
+    isTextInputFocused,
+    customColor,
+  });
+
+  return (
+    <View style={[styles.container, style]}>
+      {useNativeActivityIndicator ? (
+        <RNActivityIndicator color={indicatorColor} testID={testID} {...rest} />
+      ) : (
+        <ActivityIndicator {...rest} color={indicatorColor} testID={testID} />
+      )}
+    </View>
+  );
+};
+
+TextInputActivityIndicator.displayName = 'TextInput.ActivityIndicator';
+
+const styles = StyleSheet.create({
+  container: {
+    position: 'absolute',
+    width: ICON_SIZE,
+    height: ICON_SIZE,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+});
+
+export default TextInputActivityIndicator;
+
+// @component-docs ignore-next-line
+export { ActivityIndicatorAdornment };

--- a/src/components/TextInput/Adornment/TextInputAdornment.tsx
+++ b/src/components/TextInput/Adornment/TextInputAdornment.tsx
@@ -18,6 +18,7 @@ import type {
   AdornmentStyleAdjustmentForNativeInput,
 } from './types';
 import ActivityIndicator from '../../../components/ActivityIndicator';
+import { useInternalTheme } from '../../../core/theming';
 import { getConstants } from '../helpers';
 
 export function getAdornmentConfig({
@@ -125,6 +126,7 @@ export interface TextInputAdornmentProps {
       [AdornmentSide.Right]: number | null;
     };
     [AdornmentType.Icon]: number;
+    [AdornmentType.Loading]: number;
   };
   onAffixChange: {
     [AdornmentSide.Left]: (event: LayoutChangeEvent) => void;
@@ -161,6 +163,8 @@ const TextInputAdornment: React.FunctionComponent<TextInputAdornmentProps> = ({
   loadingStyle,
   useNativeActivityIndicator,
 }) => {
+  const { isV3 } = useInternalTheme(theme);
+  const { ICON_OFFSET } = getConstants(isV3);
   if (adornmentConfig.length) {
     return (
       <>
@@ -206,8 +210,10 @@ const TextInputAdornment: React.FunctionComponent<TextInputAdornmentProps> = ({
           } else if (type === AdornmentType.Loading) {
             const style: StyleProp<ViewStyle> = [
               {
-                top: topPosition[AdornmentType.Icon],
-                [side]: 12,
+                top: topPosition[AdornmentType.Loading],
+                [side]: useNativeActivityIndicator
+                  ? ICON_OFFSET + 2
+                  : ICON_OFFSET,
                 position: 'absolute',
               },
               loadingStyle,

--- a/src/components/TextInput/Adornment/TextInputAdornment.tsx
+++ b/src/components/TextInput/Adornment/TextInputAdornment.tsx
@@ -1,10 +1,12 @@
 import React from 'react';
-import type {
-  LayoutChangeEvent,
-  TextStyle,
-  StyleProp,
-  Animated,
+import {
+  type LayoutChangeEvent,
+  type TextStyle,
+  type StyleProp,
+  type Animated,
+  ViewStyle,
 } from 'react-native';
+import { ActivityIndicator as RNActivityIndicator } from 'react-native';
 
 import type { ThemeProp } from 'src/types';
 
@@ -15,6 +17,7 @@ import type {
   AdornmentConfig,
   AdornmentStyleAdjustmentForNativeInput,
 } from './types';
+import ActivityIndicator from '../../../components/ActivityIndicator';
 import { getConstants } from '../helpers';
 
 export function getAdornmentConfig({
@@ -36,6 +39,8 @@ export function getAdornmentConfig({
           type = AdornmentType.Affix;
         } else if (adornment.type === TextInputIcon) {
           type = AdornmentType.Icon;
+        } else if (adornment.type === ActivityIndicator) {
+          type = AdornmentType.Loading;
         }
         adornmentConfig.push({
           side,
@@ -134,6 +139,9 @@ export interface TextInputAdornmentProps {
   maxFontSizeMultiplier?: number | undefined | null;
   theme?: ThemeProp;
   disabled?: boolean;
+  loading?: boolean;
+  loadingStyle?: StyleProp<ViewStyle>;
+  useNativeActivityIndicator?: boolean;
 }
 
 const TextInputAdornment: React.FunctionComponent<TextInputAdornmentProps> = ({
@@ -150,6 +158,8 @@ const TextInputAdornment: React.FunctionComponent<TextInputAdornmentProps> = ({
   maxFontSizeMultiplier,
   theme,
   disabled,
+  loadingStyle,
+  useNativeActivityIndicator,
 }) => {
   if (adornmentConfig.length) {
     return (
@@ -191,6 +201,25 @@ const TextInputAdornment: React.FunctionComponent<TextInputAdornmentProps> = ({
                 onLayout={onAffixChange[side]}
                 visible={visible}
                 maxFontSizeMultiplier={maxFontSizeMultiplier}
+              />
+            );
+          } else if (type === AdornmentType.Loading) {
+            const style: StyleProp<ViewStyle> = [
+              {
+                top: topPosition[AdornmentType.Icon],
+                [side]: 12,
+                position: 'absolute',
+              },
+              loadingStyle,
+            ];
+
+            return useNativeActivityIndicator ? (
+              <RNActivityIndicator key={side} style={style} />
+            ) : (
+              <ActivityIndicator
+                key={side}
+                style={style}
+                onLayout={onAffixChange[side]}
               />
             );
           } else {

--- a/src/components/TextInput/Adornment/enums.tsx
+++ b/src/components/TextInput/Adornment/enums.tsx
@@ -1,7 +1,7 @@
 export enum AdornmentType {
   Icon = 'icon',
   Affix = 'affix',
-  Loading = 'loading',
+  ActivityIndicator = 'activityIndicator',
 }
 export enum AdornmentSide {
   Right = 'right',

--- a/src/components/TextInput/Adornment/enums.tsx
+++ b/src/components/TextInput/Adornment/enums.tsx
@@ -1,6 +1,7 @@
 export enum AdornmentType {
   Icon = 'icon',
   Affix = 'affix',
+  Loading = 'loading',
 }
 export enum AdornmentSide {
   Right = 'right',

--- a/src/components/TextInput/TextInput.tsx
+++ b/src/components/TextInput/TextInput.tsx
@@ -52,11 +52,11 @@ export type Props = React.ComponentPropsWithRef<typeof NativeTextInput> & {
    */
   loadingStyle?: StyleProp<ViewStyle>;
   /**
-   * Any styles that should be applied to the loading indicator
+   * Any styles that should be applied to the activity indicator
    */
-  useNativeLoadingIndicator?: boolean;
+  useNativeActivityIndicator?: boolean;
   /**
-   * Whether to use RN Paper loading indicator or native loading indicator
+   * Whether to use RN Paper activity indicator or native activity indicator
    */
   label?: TextInputLabelProp;
   /**
@@ -238,6 +238,7 @@ const TextInput = forwardRef<TextInputHandles, Props>(
       contentStyle,
       render = DefaultRenderer,
       theme: themeOverrides,
+      useNativeActivityIndicator,
       ...rest
     }: Props,
     ref
@@ -494,8 +495,6 @@ const TextInput = forwardRef<TextInputHandles, Props>(
 
     const { maxFontSizeMultiplier = 1.5 } = rest;
 
-    console.log(`useNativeLoadingIndicator: ${rest.useNativeLoadingIndicator}`);
-
     if (mode === 'outlined') {
       return (
         <TextInputOutlined
@@ -503,7 +502,7 @@ const TextInput = forwardRef<TextInputHandles, Props>(
           disabled={disabled}
           loading={rest.loading}
           loadingStyle={rest.loadingStyle}
-          useNativeLoadingIndicator={rest.useNativeLoadingIndicator}
+          useNativeActivityIndicator={useNativeActivityIndicator}
           error={errorProp}
           multiline={multiline}
           editable={editable}
@@ -547,7 +546,7 @@ const TextInput = forwardRef<TextInputHandles, Props>(
         disabled={disabled}
         loading={rest.loading}
         loadingStyle={rest.loadingStyle}
-        useNativeLoadingIndicator={rest.useNativeLoadingIndicator}
+        useNativeActivityIndicator={useNativeActivityIndicator}
         error={errorProp}
         multiline={multiline}
         editable={editable}

--- a/src/components/TextInput/TextInput.tsx
+++ b/src/components/TextInput/TextInput.tsx
@@ -46,6 +46,18 @@ export type Props = React.ComponentPropsWithRef<typeof NativeTextInput> & {
   /**
    * The text or component to use for the floating label.
    */
+  loading?: boolean;
+  /**
+   * Override any 'right' icon with an activity indicator.
+   */
+  loadingStyle?: StyleProp<ViewStyle>;
+  /**
+   * Any styles that should be applied to the loading indicator
+   */
+  useNativeLoadingIndicator?: boolean;
+  /**
+   * Whether to use RN Paper loading indicator or native loading indicator
+   */
   label?: TextInputLabelProp;
   /**
    * Placeholder for the input.
@@ -482,11 +494,16 @@ const TextInput = forwardRef<TextInputHandles, Props>(
 
     const { maxFontSizeMultiplier = 1.5 } = rest;
 
+    console.log(`useNativeLoadingIndicator: ${rest.useNativeLoadingIndicator}`);
+
     if (mode === 'outlined') {
       return (
         <TextInputOutlined
           dense={dense}
           disabled={disabled}
+          loading={rest.loading}
+          loadingStyle={rest.loadingStyle}
+          useNativeLoadingIndicator={rest.useNativeLoadingIndicator}
           error={errorProp}
           multiline={multiline}
           editable={editable}
@@ -528,6 +545,9 @@ const TextInput = forwardRef<TextInputHandles, Props>(
       <TextInputFlat
         dense={dense}
         disabled={disabled}
+        loading={rest.loading}
+        loadingStyle={rest.loadingStyle}
+        useNativeLoadingIndicator={rest.useNativeLoadingIndicator}
         error={errorProp}
         multiline={multiline}
         editable={editable}

--- a/src/components/TextInput/TextInput.tsx
+++ b/src/components/TextInput/TextInput.tsx
@@ -10,6 +10,9 @@ import {
   TextLayoutEventData,
 } from 'react-native';
 
+import TextInputActivityIndicator, {
+  Props as TextInputActivityIndicatorProps,
+} from './Adornment/TextInputActivityIndicator';
 import TextInputAffix, {
   Props as TextInputAffixProps,
 } from './Adornment/TextInputAffix';
@@ -45,18 +48,6 @@ export type Props = React.ComponentPropsWithRef<typeof NativeTextInput> & {
   disabled?: boolean;
   /**
    * The text or component to use for the floating label.
-   */
-  loading?: boolean;
-  /**
-   * Override any 'right' icon with an activity indicator.
-   */
-  loadingStyle?: StyleProp<ViewStyle>;
-  /**
-   * Any styles that should be applied to the activity indicator
-   */
-  useNativeActivityIndicator?: boolean;
-  /**
-   * Whether to use RN Paper activity indicator or native activity indicator
    */
   label?: TextInputLabelProp;
   /**
@@ -192,6 +183,7 @@ interface CompoundedComponent
   > {
   Icon: React.FunctionComponent<TextInputIconProps>;
   Affix: React.FunctionComponent<Partial<TextInputAffixProps>>;
+  ActivityIndicator: React.FunctionComponent<TextInputActivityIndicatorProps>;
 }
 
 type TextInputHandles = Pick<
@@ -238,7 +230,6 @@ const TextInput = forwardRef<TextInputHandles, Props>(
       contentStyle,
       render = DefaultRenderer,
       theme: themeOverrides,
-      useNativeActivityIndicator,
       ...rest
     }: Props,
     ref
@@ -500,9 +491,6 @@ const TextInput = forwardRef<TextInputHandles, Props>(
         <TextInputOutlined
           dense={dense}
           disabled={disabled}
-          loading={rest.loading}
-          loadingStyle={rest.loadingStyle}
-          useNativeActivityIndicator={useNativeActivityIndicator}
           error={errorProp}
           multiline={multiline}
           editable={editable}
@@ -544,9 +532,6 @@ const TextInput = forwardRef<TextInputHandles, Props>(
       <TextInputFlat
         dense={dense}
         disabled={disabled}
-        loading={rest.loading}
-        loadingStyle={rest.loadingStyle}
-        useNativeActivityIndicator={useNativeActivityIndicator}
         error={errorProp}
         multiline={multiline}
         editable={editable}
@@ -590,5 +575,8 @@ TextInput.Icon = TextInputIcon;
 // @component ./Adornment/TextInputAffix.tsx
 // @ts-ignore Types of property 'theme' are incompatible.
 TextInput.Affix = TextInputAffix;
+
+// @component ./Adornment/TextInputActivityIndicator.tsx
+TextInput.ActivityIndicator = TextInputActivityIndicator;
 
 export default TextInput;

--- a/src/components/TextInput/TextInputFlat.tsx
+++ b/src/components/TextInput/TextInputFlat.tsx
@@ -41,7 +41,6 @@ import {
 } from './helpers';
 import InputLabel from './Label/InputLabel';
 import type { ChildTextInputProps, RenderProps } from './types';
-import ActivityIndicator from '../ActivityIndicator';
 
 const TextInputFlat = ({
   disabled = false,
@@ -75,9 +74,6 @@ const TextInputFlat = ({
   placeholderTextColor,
   testID = 'text-input-flat',
   contentStyle,
-  loading,
-  loadingStyle,
-  useNativeActivityIndicator = false,
   ...rest
 }: ChildTextInputProps) => {
   const isAndroid = Platform.OS === 'android';
@@ -103,10 +99,6 @@ const TextInputFlat = ({
 
   const isPaddingHorizontalPassed =
     paddingHorizontal !== undefined && typeof paddingHorizontal === 'number';
-
-  if (loading) {
-    right = <ActivityIndicator />;
-  }
 
   const adornmentConfig = getAdornmentConfig({
     left,
@@ -245,8 +237,8 @@ const TextInputFlat = ({
     (!height ? (dense ? LABEL_PADDING_TOP_DENSE : LABEL_PADDING_TOP) : 0);
 
   const iconTopPosition = (flatHeight - ADORNMENT_SIZE) / 2;
-  const loadingTopPosition =
-    (flatHeight - (useNativeActivityIndicator ? 20 : ADORNMENT_SIZE)) / 2;
+
+  const loadingTopPosition = iconTopPosition;
 
   const leftAffixTopPosition = leftLayout.height
     ? calculateFlatAffixTopPosition({
@@ -325,15 +317,12 @@ const TextInputFlat = ({
     topPosition: {
       [AdornmentType.Affix]: affixTopPosition,
       [AdornmentType.Icon]: iconTopPosition,
-      [AdornmentType.Loading]: loadingTopPosition,
+      [AdornmentType.ActivityIndicator]: loadingTopPosition,
     },
     onAffixChange,
     isTextInputFocused: parentState.focused,
     maxFontSizeMultiplier: rest.maxFontSizeMultiplier,
     disabled,
-    loading,
-    loadingStyle,
-    useNativeActivityIndicator,
   };
   if (adornmentConfig.length) {
     adornmentProps = {

--- a/src/components/TextInput/TextInputFlat.tsx
+++ b/src/components/TextInput/TextInputFlat.tsx
@@ -245,6 +245,8 @@ const TextInputFlat = ({
     (!height ? (dense ? LABEL_PADDING_TOP_DENSE : LABEL_PADDING_TOP) : 0);
 
   const iconTopPosition = (flatHeight - ADORNMENT_SIZE) / 2;
+  const loadingTopPosition =
+    (flatHeight - (useNativeActivityIndicator ? 20 : ADORNMENT_SIZE)) / 2;
 
   const leftAffixTopPosition = leftLayout.height
     ? calculateFlatAffixTopPosition({
@@ -323,6 +325,7 @@ const TextInputFlat = ({
     topPosition: {
       [AdornmentType.Affix]: affixTopPosition,
       [AdornmentType.Icon]: iconTopPosition,
+      [AdornmentType.Loading]: loadingTopPosition,
     },
     onAffixChange,
     isTextInputFocused: parentState.focused,

--- a/src/components/TextInput/TextInputFlat.tsx
+++ b/src/components/TextInput/TextInputFlat.tsx
@@ -41,6 +41,7 @@ import {
 } from './helpers';
 import InputLabel from './Label/InputLabel';
 import type { ChildTextInputProps, RenderProps } from './types';
+import ActivityIndicator from '../ActivityIndicator';
 
 const TextInputFlat = ({
   disabled = false,
@@ -74,6 +75,9 @@ const TextInputFlat = ({
   placeholderTextColor,
   testID = 'text-input-flat',
   contentStyle,
+  loading,
+  loadingStyle,
+  useNativeActivityIndicator = false,
   ...rest
 }: ChildTextInputProps) => {
   const isAndroid = Platform.OS === 'android';
@@ -99,6 +103,10 @@ const TextInputFlat = ({
 
   const isPaddingHorizontalPassed =
     paddingHorizontal !== undefined && typeof paddingHorizontal === 'number';
+
+  if (loading) {
+    right = <ActivityIndicator />;
+  }
 
   const adornmentConfig = getAdornmentConfig({
     left,
@@ -320,6 +328,9 @@ const TextInputFlat = ({
     isTextInputFocused: parentState.focused,
     maxFontSizeMultiplier: rest.maxFontSizeMultiplier,
     disabled,
+    loading,
+    loadingStyle,
+    useNativeActivityIndicator,
   };
   if (adornmentConfig.length) {
     adornmentProps = {

--- a/src/components/TextInput/TextInputOutlined.tsx
+++ b/src/components/TextInput/TextInputOutlined.tsx
@@ -79,7 +79,7 @@ const TextInputOutlined = ({
   testID = 'text-input-outlined',
   contentStyle,
   loadingStyle,
-  useNativeActivityIndicator = false,
+  useNativeActivityIndicator,
   ...rest
 }: ChildTextInputProps) => {
   if (loading) {
@@ -291,6 +291,11 @@ const TextInputOutlined = ({
     affixHeight: ADORNMENT_SIZE,
     labelYOffset: -yOffset,
   });
+  const loadingTopPosition = calculateOutlinedIconAndAffixTopPosition({
+    height: outlinedHeight,
+    affixHeight: useNativeActivityIndicator ? 20 : 24,
+    labelYOffset: -yOffset,
+  });
 
   const rightAffixWidth = right
     ? rightLayout.width || ADORNMENT_SIZE
@@ -323,14 +328,16 @@ const TextInputOutlined = ({
     topPosition: {
       [AdornmentType.Icon]: iconTopPosition,
       [AdornmentType.Affix]: affixTopPosition,
+      [AdornmentType.Loading]: loadingTopPosition,
     },
     onAffixChange,
     isTextInputFocused: parentState.focused,
     maxFontSizeMultiplier: rest.maxFontSizeMultiplier,
     disabled,
     loadingStyle,
-    useNativeActivityIndicator,
+    useNativeActivityIndicator: !!useNativeActivityIndicator,
   };
+
   if (adornmentConfig.length) {
     adornmentProps = {
       ...adornmentProps,

--- a/src/components/TextInput/TextInputOutlined.tsx
+++ b/src/components/TextInput/TextInputOutlined.tsx
@@ -285,30 +285,9 @@ const TextInputOutlined = ({
     labelYOffset: -yOffset,
   });
 
-  // let useNativeActivityIndicator = false;
-  // const activityIndicatorIndex = adornmentConfig.findIndex(
-  //   (a) => a.type === AdornmentType.ActivityIndicator
-  // );
-  // if (activityIndicatorIndex !== -1) {
-  //   if (adornmentConfig[activityIndicatorIndex].side === AdornmentSide.Left) {
-  //     useNativeActivityIndicator =
-  //       React.isValidElement(left) &&
-  //       left.props.useNativeActivityIndicator === true;
-  //   } else if (
-  //     adornmentConfig[activityIndicatorIndex].side === AdornmentSide.Right
-  //   ) {
-  //     useNativeActivityIndicator =
-  //       React.isValidElement(right) &&
-  //       right.props.useNativeActivityIndicator === true;
-  //   }
-  // }
-
   const loadingTopPosition = calculateOutlinedIconAndAffixTopPosition({
     height: outlinedHeight,
     affixHeight: ADORNMENT_SIZE,
-    // useNativeActivityIndicator
-    //   ? REACT_NATIVE_ACTIVITY_INDICATOR_SMALL_SIZE
-    //   : ICON_SIZE,
     labelYOffset: -yOffset,
   });
 

--- a/src/components/TextInput/TextInputOutlined.tsx
+++ b/src/components/TextInput/TextInputOutlined.tsx
@@ -41,11 +41,9 @@ import {
 import InputLabel from './Label/InputLabel';
 import LabelBackground from './Label/LabelBackground';
 import type { RenderProps, ChildTextInputProps } from './types';
-import ActivityIndicator from '../ActivityIndicator';
 
 const TextInputOutlined = ({
   disabled = false,
-  loading = false,
   editable = true,
   label,
   error = false,
@@ -78,13 +76,8 @@ const TextInputOutlined = ({
   placeholderTextColor,
   testID = 'text-input-outlined',
   contentStyle,
-  loadingStyle,
-  useNativeActivityIndicator,
   ...rest
 }: ChildTextInputProps) => {
-  if (loading) {
-    right = <ActivityIndicator />;
-  }
   const adornmentConfig = getAdornmentConfig({ left, right });
 
   const { colors, isV3, roundness } = theme;
@@ -291,9 +284,31 @@ const TextInputOutlined = ({
     affixHeight: ADORNMENT_SIZE,
     labelYOffset: -yOffset,
   });
+
+  // let useNativeActivityIndicator = false;
+  // const activityIndicatorIndex = adornmentConfig.findIndex(
+  //   (a) => a.type === AdornmentType.ActivityIndicator
+  // );
+  // if (activityIndicatorIndex !== -1) {
+  //   if (adornmentConfig[activityIndicatorIndex].side === AdornmentSide.Left) {
+  //     useNativeActivityIndicator =
+  //       React.isValidElement(left) &&
+  //       left.props.useNativeActivityIndicator === true;
+  //   } else if (
+  //     adornmentConfig[activityIndicatorIndex].side === AdornmentSide.Right
+  //   ) {
+  //     useNativeActivityIndicator =
+  //       React.isValidElement(right) &&
+  //       right.props.useNativeActivityIndicator === true;
+  //   }
+  // }
+
   const loadingTopPosition = calculateOutlinedIconAndAffixTopPosition({
     height: outlinedHeight,
-    affixHeight: useNativeActivityIndicator ? 20 : 24,
+    affixHeight: ADORNMENT_SIZE,
+    // useNativeActivityIndicator
+    //   ? REACT_NATIVE_ACTIVITY_INDICATOR_SMALL_SIZE
+    //   : ICON_SIZE,
     labelYOffset: -yOffset,
   });
 
@@ -328,16 +343,13 @@ const TextInputOutlined = ({
     topPosition: {
       [AdornmentType.Icon]: iconTopPosition,
       [AdornmentType.Affix]: affixTopPosition,
-      [AdornmentType.Loading]: loadingTopPosition,
+      [AdornmentType.ActivityIndicator]: loadingTopPosition,
     },
     onAffixChange,
     isTextInputFocused: parentState.focused,
     maxFontSizeMultiplier: rest.maxFontSizeMultiplier,
     disabled,
-    loadingStyle,
-    useNativeActivityIndicator: !!useNativeActivityIndicator,
   };
-
   if (adornmentConfig.length) {
     adornmentProps = {
       ...adornmentProps,

--- a/src/components/TextInput/TextInputOutlined.tsx
+++ b/src/components/TextInput/TextInputOutlined.tsx
@@ -41,9 +41,11 @@ import {
 import InputLabel from './Label/InputLabel';
 import LabelBackground from './Label/LabelBackground';
 import type { RenderProps, ChildTextInputProps } from './types';
+import ActivityIndicator from '../ActivityIndicator';
 
 const TextInputOutlined = ({
   disabled = false,
+  loading = false,
   editable = true,
   label,
   error = false,
@@ -76,8 +78,13 @@ const TextInputOutlined = ({
   placeholderTextColor,
   testID = 'text-input-outlined',
   contentStyle,
+  loadingStyle,
+  useNativeActivityIndicator = false,
   ...rest
 }: ChildTextInputProps) => {
+  if (loading) {
+    right = <ActivityIndicator />;
+  }
   const adornmentConfig = getAdornmentConfig({ left, right });
 
   const { colors, isV3, roundness } = theme;
@@ -321,6 +328,8 @@ const TextInputOutlined = ({
     isTextInputFocused: parentState.focused,
     maxFontSizeMultiplier: rest.maxFontSizeMultiplier,
     disabled,
+    loadingStyle,
+    useNativeActivityIndicator,
   };
   if (adornmentConfig.length) {
     adornmentProps = {

--- a/src/components/TextInput/constants.tsx
+++ b/src/components/TextInput/constants.tsx
@@ -46,6 +46,3 @@ export const MD3_OUTLINED_INPUT_OFFSET = 16;
 
 export const OUTLINE_MINIMIZED_LABEL_Y_OFFSET = -6;
 export const MIN_DENSE_HEIGHT_OUTLINED = 48;
-
-// React Native Activity Indicator
-export const REACT_NATIVE_ACTIVITY_INDICATOR_SMALL_SIZE = 20;

--- a/src/components/TextInput/constants.tsx
+++ b/src/components/TextInput/constants.tsx
@@ -46,3 +46,6 @@ export const MD3_OUTLINED_INPUT_OFFSET = 16;
 
 export const OUTLINE_MINIMIZED_LABEL_Y_OFFSET = -6;
 export const MIN_DENSE_HEIGHT_OUTLINED = 48;
+
+// React Native Activity Indicator
+export const REACT_NATIVE_ACTIVITY_INDICATOR_SMALL_SIZE = 20;

--- a/src/components/TextInput/types.tsx
+++ b/src/components/TextInput/types.tsx
@@ -21,6 +21,8 @@ type TextInputProps = React.ComponentPropsWithRef<typeof NativeTextInput> & {
   left?: React.ReactNode;
   right?: React.ReactNode;
   disabled?: boolean;
+  useNativeActivityIndicator?: boolean;
+  loading?: boolean;
   label?: TextInputLabelProp;
   placeholder?: string;
   error?: boolean;
@@ -45,6 +47,7 @@ type TextInputProps = React.ComponentPropsWithRef<typeof NativeTextInput> & {
   contentStyle?: StyleProp<TextStyle>;
   outlineStyle?: StyleProp<ViewStyle>;
   underlineStyle?: StyleProp<ViewStyle>;
+  loadingStyle?: StyleProp<ViewStyle>;
 };
 
 export type RenderProps = {


### PR DESCRIPTION
- Add a new `TextInput.ActivityIndicator` to use with `TextInput` `right` and `left` props
--> This will show either the native activity indicator or the RN Paper Activity Indicator,
       based on the value of the `useNativeActivityIndicator` prop